### PR TITLE
Add AUR package instruction to Readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -28,6 +28,11 @@ Retro top-down and isometric perspectives as well as low-poly meshes will be sup
 
 You can download the current pre-release in [Releases](https://github.com/markusmoenig/Eldiron/releases).
 
+For ArchLinux users, simply add Eldiron from AUR:
+```
+yay -S eldiron
+```
+
 Join the community on [Discord](https://discord.gg/ZrNj6baSZU) to get in contact.
 
 ## Goals


### PR DESCRIPTION
I added AUR package instruction to Readme.

Maybe later can move to a new section named `installation` or something like that with instructions on other systems.