### PR TITLE
Support binary encoding for ServerCmd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,6 +167,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bindgen"
 version = "0.59.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -342,8 +351,6 @@ dependencies = [
  "png",
  "rand",
  "rhai",
- "serde",
- "serde_json",
  "uuid",
  "vectorize",
  "winit",
@@ -632,6 +639,7 @@ dependencies = [
 name = "core_shared"
 version = "0.1.0"
 dependencies = [
+ "bincode",
  "colors-transform",
  "core_embed_binaries",
  "cpal 0.15.1",
@@ -2627,8 +2635,6 @@ dependencies = [
  "png",
  "rand",
  "rhai",
- "serde",
- "serde_json",
  "vectorize",
 ]
 

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -14,8 +14,6 @@ pixels = "0.11.0"
 winit = "0.27.5"
 winit_input_helper = "0.13"
 png = "0.17.5"
-serde = { version = "1.0.144", features = ["derive"] }
-serde_json = "1.0"
 fontdue = "0.7.2"
 vectorize = "0.2.0"
 itertools = "0.10.2"

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -47,13 +47,12 @@ fn main() -> Result<(), Error> {
             NodeEvent::Network(net_event) => match net_event {
                 NetEvent::Connected(_endpoint, _ok) => {
                     let cmd = ServerCmd::LoginAnonymous;
-                    if let Some(json) = cmd.to_json() {
-                        handler.network().send(server, json.as_bytes());
+                    if let Some(bin) = cmd.to_bin() {
+                        handler.network().send(server, &bin);
                     }
                 },
                 NetEvent::Message(_endpoint, data) => {
-                    let cmd_string = String::from_utf8_lossy(data);
-                    let cmd : ServerCmd = serde_json::from_str(&cmd_string).ok()
+                    let cmd : ServerCmd = ServerCmd::from_bin(data)
                         .unwrap_or(ServerCmd::NoOp);
 
                     match cmd {
@@ -73,8 +72,8 @@ fn main() -> Result<(), Error> {
                 let t : Option<String> = cmd_receiver.try_recv().ok();
                 if t.is_some() {
                     let cmd = ServerCmd::GameCmd(t.unwrap());
-                    if let Some(to_send) = cmd.to_json() {
-                        handler.network().send(server, to_send.as_bytes());
+                    if let Some(bin) = cmd.to_bin() {
+                        handler.network().send(server, &bin);
                     }
                 }
                 handler.signals().send_with_timer((), Duration::from_millis(10));

--- a/core_shared/Cargo.toml
+++ b/core_shared/Cargo.toml
@@ -24,6 +24,7 @@ cpal = "0.15.1"
 colors-transform = "0.2.11"
 rhai = { version = "1.11.0", default-features = true, features = ["only_i32", "f32_float"] }
 rustc-hash = "1.1.0"
+bincode = "1.3.3"
 
 [features]
 default = ["embed_binaries"]

--- a/core_shared/src/server.rs
+++ b/core_shared/src/server.rs
@@ -18,4 +18,20 @@ impl ServerCmd {
             None
         }
     }
+
+    pub fn to_bin(&self) -> Option<Vec<u8>> {
+        if let Ok(bin) = bincode::serialize(&self) {
+            Some(bin)
+        } else {
+            None
+        }
+    }
+
+    pub fn from_bin(bin: &[u8]) -> Option<Self> {
+        if let Ok(data) = bincode::deserialize(&bin) {
+            Some(data)
+        } else {
+            None
+        }
+    }
 }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -10,8 +10,6 @@ core_shared = { path = "../core_shared" }
 env_logger = "0.10"
 log = "0.4"
 png = "0.17.5"
-serde = { version = "1.0.144", features = ["derive"] }
-serde_json = "1.0"
 vectorize = "0.2.0"
 itertools = "0.10.2"
 getrandom = { version = "0.2.7", features = ["js"] }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -56,8 +56,7 @@ fn main() {
             },
             NetEvent::Message(endpoint, data) => {
 
-                let cmd_string = String::from_utf8_lossy(data);
-                let cmd : ServerCmd = serde_json::from_str(&cmd_string).ok()
+                let cmd : ServerCmd = ServerCmd::from_bin(&data)
                     .unwrap_or(ServerCmd::NoOp);
 
                 match cmd {
@@ -99,9 +98,9 @@ fn main() {
                         Message::PlayerUpdate(_uuid, update) => {
                             if let Some(client) = uuid_endpoint.get(&update.id) {
                                 let cmd = ServerCmd::GameUpdate(update);
-                                if let Some(json) = cmd.to_json() {
-                                    //println!("{:?}", json.len());
-                                    handler.network().send(*client, json.as_bytes());
+                                if let Some(bin) = cmd.to_bin() {
+                                    //println!("{:?}", bin.len());
+                                    handler.network().send(*client, &bin);
                                 }
                             }
                         },


### PR DESCRIPTION
Support binary encoding for ServerCmd.

It's much more compact compared to JSON.

Also removed the unused `serde` and `serde_json` crates in `client` and `server`.