### PR TITLE
Update AUR package name

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -42,7 +42,7 @@ On macOS you can get access to the current Beta via a public [TestFlight Link](h
 
 For ArchLinux users, simply add Eldiron from AUR:
 ```
-yay -S eldiron
+yay -S eldiron-bin
 ```
 
 ## Building Eldiron Locally


### PR DESCRIPTION
AUR package is moved to `eldiron-bin` to follow the community's [guidelines](https://wiki.archlinux.org/title/AUR_submission_guidelines#Rules_of_submission)