### PR TITLE
snap fractional dpi to nearest integer on non-macOS devices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ clients/solo/embedded/*.eldiron
 users
 Untitled*
 Xcode/Eldiron/librustapi.a
+CLAUDE.md

--- a/crates/theframework/src/thewinitapp.rs
+++ b/crates/theframework/src/thewinitapp.rs
@@ -344,15 +344,25 @@ impl TheWinitApp {
 
             let scale_factor = ctx.window.scale_factor() as f32;
 
-            // On non-macOS, if DPI scale is fractional, render at physical resolution with scale_factor forced to 1.0
+            // On non-macOS, snap fractional DPI scales to the nearest integer. The UI is
+            // magnified with a nearest neighbor blit, which only looks right at integer
+            // factors, but falling back to 1.0 leaves the UI at native pixel size on the
+            // fractional scales HiDPI desktops actually use (1.25, 1.5, 2.25).
+            // Cap the magnification so the app's minimum layout always fits the buffer.
             #[cfg(all(not(target_os = "macos"), not(target_arch = "wasm32")))]
-            let (effective_scale, width, height) = if scale_factor.fract() != 0.0 {
-                (1.0_f32, size.width, size.height)
-            } else {
+            let (effective_scale, width, height) = {
+                let (min_width, min_height) = self.app.min_window_size();
+                let fits = (size.width as f32 / min_width as f32)
+                    .min(size.height as f32 / min_height as f32)
+                    .floor();
+                let snapped = scale_factor.round().min(fits).max(1.0);
+                // Floor the buffer dimensions: the pixels backend floors the
+                // surface/buffer ratio, so a buffer even one pixel too large
+                // drops the displayed scale to snapped - 1 and letterboxes.
                 (
-                    scale_factor,
-                    (size.width as f32 / scale_factor).round() as u32,
-                    (size.height as f32 / scale_factor).round() as u32,
+                    snapped,
+                    (size.width as f32 / snapped).floor() as u32,
+                    (size.height as f32 / snapped).floor() as u32,
                 )
             };
             // macOS and WASM: keep logical sizing based on scale_factor


### PR DESCRIPTION
Hey yo
This is a pull request on a patch I made to be able to run the creator on my clevo linux laptop. It works well but it would obviously need more testing with different systems (and especially windows). I also don't know the project's policy on ai-assisted programming.